### PR TITLE
chore(footer): updated academic calendar link to 2025-26

### DIFF
--- a/apps/web/src/data/footer-links.ts
+++ b/apps/web/src/data/footer-links.ts
@@ -7,7 +7,7 @@ export const footerLinks = [
       { text: "Research", href: "/academics/research" },
       {
         text: "Academic Calendar",
-        href: "https://iiitdwd.ac.in/docs/Academic_Calendar_year_234_2024-25.pdf",
+        href: "https://iiitdwd.ac.in/docs/Academic_Calendar_2025-26_Aug-Nov_25.pdf",
       },
       {
         text: "Curriculum",


### PR DESCRIPTION
Updated the href attribute in apps/web/src/data/footer-links.ts to point to the current academic calendar.

Changed from:
https://iiitdwd.ac.in/docs/Academic_Calendar_year_234_2024-25.pdf

Changed to:
https://iiitdwd.ac.in/docs/Academic_Calendar_2025-26_Aug-Nov_25.pdf

Please review and merge