### PR TITLE
chore(data): update placement stats and CTC for 2025 in placements/page.tsx

### DIFF
--- a/apps/web/src/app/(other)/faq/page.tsx
+++ b/apps/web/src/app/(other)/faq/page.tsx
@@ -51,7 +51,10 @@ Admission to the Indian Institute of Information Technology Dharwad is through C
               Science and Engineering (CSE), Data Science and Artificial
               Intelligence (DSAI), and Electronics and Communication Engineering
               (ECE). The details of the programs can be found{" "}
-              <a className="text-blue-800 hover:underline" href="/academics">
+              <a
+                className="text-blue-800 hover:underline"
+                href="/academics/programmes"
+              >
                 at this page.
               </a>
             </div>
@@ -69,7 +72,10 @@ Admission to the Indian Institute of Information Technology Dharwad is through C
               India as well as USA. With energy and commitment, faculty are
               working on setting high standards in both teaching/learning, and
               R&D. Faculty profiles can be found
-              <a className="text-blue-800 hover:underline" href="/faculty">
+              <a
+                className="text-blue-800 hover:underline"
+                href="/academics/faculty/"
+              >
                 {" "}
                 here.
               </a>
@@ -92,7 +98,7 @@ Admission to the Indian Institute of Information Technology Dharwad is through C
               and research. The campus is equipped with advanced laboratories,
               spacious classrooms, auditoriums, sports facilities, and
               residential accommodation for
-              <a className="text-blue-800 hover:underline" href="/facilities">
+              <a className="text-blue-800 hover:underline" href="/amenities">
                 {" "}
                 students.
               </a>

--- a/apps/web/src/app/placements/placement-stats.tsx
+++ b/apps/web/src/app/placements/placement-stats.tsx
@@ -62,12 +62,12 @@ export default function PlacementStatistics() {
       placementPercentage: 62,
     },
     "2025": {
-      companies: 86,
-      offers: 203, // Estimated based on trend
-      highestCTC: 71.94,
-      averageCTC: 11.9,
+      companies: 94,
+      offers: 214, // Estimated based on trend
+      highestCTC: 78.12,
+      averageCTC: 12,
       medianCTC: 9.34,
-      placementPercentage: 77.23,
+      placementPercentage: 82,
     },
   };
 


### PR DESCRIPTION
Previously it was updated in the home page of the website without making the change in the main /placements page. This commit ensures that change too