### PR TITLE
fix: implement proper Recently Updated sorting for tenders

### DIFF
--- a/apps/web/src/app/(institute)/tenders/SortSearch.tsx
+++ b/apps/web/src/app/(institute)/tenders/SortSearch.tsx
@@ -13,7 +13,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 type SortSearchProps = {
   selectedTab: string;
@@ -40,7 +40,7 @@ export default function SortSearch({
   archiveData,
   setActiveData,
   setArchiveData,
-}: SortSearchProps) {
+}: SortSearchProps): JSX.Element {
   const [sortAsc, setSortAsc] = useState(false);
   const [sortBy, setSortBy] = useState("Recently Updated");
   const [searchFor, setSearchFor] = useState("");
@@ -54,6 +54,12 @@ export default function SortSearch({
       [...data].sort((t1, t2) => multiplier * (t1[attr] >= t2[attr] ? 1 : -1))
     );
   };
+
+  // Apply default sorting on mount and when data changes
+  useEffect(() => {
+    const data = selectedTab === "active" ? active : archive;
+    sortAndSetData(sortBy, sortAsc, data);
+  }, [active, archive, selectedTab]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const onSortChange = (newSortBy: string, newSortAsc: boolean) => {
     setSortBy(newSortBy);

--- a/apps/web/src/app/(institute)/tenders/page.tsx
+++ b/apps/web/src/app/(institute)/tenders/page.tsx
@@ -5,7 +5,7 @@ import { queryTenders } from "@/sanity/lib/queries";
 import { QueryTendersResult } from "@/sanity/types";
 import { Metadata } from "next";
 
-export default async function TendersPage() {
+export default async function TendersPage(): Promise<JSX.Element> {
   const now = Date.now();
   const active: Tender[] = [];
   const archive: Tender[] = [];
@@ -16,6 +16,9 @@ export default async function TendersPage() {
       ...tender,
       publishDate: Date.parse(tender.publishDate as string),
       submissionDeadline: Date.parse(tender.submissionDeadline as string),
+      updatedAt: tender.updatedAt
+        ? new Date(tender.updatedAt).getTime()
+        : Date.now(),
     };
     if (newTender.cancelled || newTender.submissionDeadline <= now)
       archive.push(newTender);

--- a/apps/web/src/types/tender.d.ts
+++ b/apps/web/src/types/tender.d.ts
@@ -16,5 +16,5 @@ interface Tender {
   publishDate: string | number;
   submissionDeadline: string | number;
   title: string;
-  updatedAt: number;
+  updatedAt: string | number;
 }


### PR DESCRIPTION
- Fix updatedAt parsing to properly handle Sanity's _updatedAt field
- Add useEffect to apply default sorting on component mount
- Update Tender type definition for correct updatedAt typing
- Add proper TypeScript return type annotations

Fixes issue where Recently Updated sorting wasn't working and tenders weren't sorted by their last modification time from Sanity CMS.

## PR Type

What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Release
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Tests
[ ] Other
```

### The GH-Issue (if any)

Closes #

## What's new?

-

## Screenshots

N/A
