### PR TITLE
fix: the desktop-header keeps menubar trigger text visible when open

### DIFF
--- a/apps/web/src/components/layout/desktop-header.tsx
+++ b/apps/web/src/components/layout/desktop-header.tsx
@@ -143,6 +143,7 @@ export default function DesktopHeader() {
       {navigationData.map((item, index) => (
         <MenubarMenu key={index} value={item.title}>
           <MenubarTrigger
+            asChild={!!item?.href}
             className="font-bold text-[14.7px] leading-tight text-gray-900 hover:bg-primary hover:!text-white rounded-md px-3 py-1.5 transition-all duration-150 ease-out"
             onMouseEnter={() => setOpenMenu(item.title)}
             onClick={() =>
@@ -155,7 +156,12 @@ export default function DesktopHeader() {
             }
           >
             {item?.href ? (
-              <Link href={item?.href} className="hover:!text-white">
+              <Link
+                href={item.href}
+                className={
+                  "block font-bold text-[14.7px] leading-tight text-gray-900 hover:bg-primary hover:!text-white rounded-md px-3 py-1.5 transition-all duration-150 ease-out data-[state=open]:!text-white"
+                }
+              >
                 {item.title}
               </Link>
             ) : (


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Release
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Tests
[ ] Other
```

### The GH-Issue (if any)

Closes #
N A

## What's new?

- Fix desktop header menubar trigger so menu text remains visible when the menu is open or the cursor is inside.
  - Render top-level menu triggers as the anchor element (Radix menubar `asChild`) when a `href` exists to avoid an <a> inside a ` <button>`
  - Ensure the anchor receives the trigger sizing/hover classes and `data-[state=open]:!text-white` so the text turns white when the menu is active.


## Screenshots
<img width="1459" height="415" alt="Screenshot 2025-11-04 at 1 59 26 AM" src="https://github.com/user-attachments/assets/d38a38c2-936b-4c77-9869-65d4e7fa03f9" />

<img width="1463" height="453" alt="Screenshot 2025-11-04 at 1 59 42 AM" src="https://github.com/user-attachments/assets/d26fe7e9-d0f4-4334-8561-cab19bd19ee2" />

